### PR TITLE
fix bug where 64byte long commands would crash crow

### DIFF
--- a/crow_m4l/crowmax.lua
+++ b/crow_m4l/crowmax.lua
@@ -76,14 +76,10 @@ end
 --- Helper conversion functions
 
 function tell_crow( str )
-	if string.find( str, "^%^%^" ) then -- 3char command
+	if string.find( str, "^%^%^" ) then -- crow command
 		outlet(0, string_to_serial( string.sub( str, 1, 3)))
-	elseif string.len(str) >= 64 then -- multi-line codeblock
-		-- TODO if more than 1kB, need to split into multiple messages
-		outlet(0, string_to_serial( '```'))
-		outlet(0, string_to_serial( str))
-		outlet(0, string_to_serial( '```'))
-	else -- standard code block
+	else -- code block
+		print(string.len(str))
 		outlet(0, string_to_serial( str))
 	end
 end
@@ -94,6 +90,8 @@ function string_to_serial( str )
         table.insert(ascii, c:byte())
     end
 	table.insert(ascii, string.byte'\n')
+	-- HACK to solve line-ending issue when packets are 64bytes
+	if (#ascii % 64) == 0 then table.insert(ascii, string.byte'\n') end
     return ascii
 end
 

--- a/crow_max/crowmax.lua
+++ b/crow_max/crowmax.lua
@@ -76,14 +76,10 @@ end
 --- Helper conversion functions
 
 function tell_crow( str )
-	if string.find( str, "^%^%^" ) then -- 3char command
+	if string.find( str, "^%^%^" ) then -- crow command
 		outlet(0, string_to_serial( string.sub( str, 1, 3)))
-	elseif string.len(str) >= 64 then -- multi-line codeblock
-		-- TODO if more than 1kB, need to split into multiple messages
-		outlet(0, string_to_serial( '```'))
-		outlet(0, string_to_serial( str))
-		outlet(0, string_to_serial( '```'))
-	else -- standard code block
+	else -- code block
+		print(string.len(str))
 		outlet(0, string_to_serial( str))
 	end
 end
@@ -94,6 +90,8 @@ function string_to_serial( str )
         table.insert(ascii, c:byte())
     end
 	table.insert(ascii, string.byte'\n')
+	-- HACK to solve line-ending issue when packets are 64bytes
+	if (#ascii % 64) == 0 then table.insert(ascii, string.byte'\n') end
     return ascii
 end
 


### PR DESCRIPTION
At present, sending a `tell_crow` message that is exactly 63 bytes long will crash crow when sending the USB packet (after the \n is added).

This is a hack to add an additional `\n` (newline character) when length%64 == 0.

Also note, it removes the 'multiline' handling, as crow v1.0.1 no longer necessitates it.
Is this a bad idea? i would like to remove the multiline parser from crow as it's not needed, but this means the max & m4l objects can fail with weird errors for those that haven't updated when sending long strings.

In the interim, we could leave in the mutliline handling, then remove it once we get to v1.1.0 crow when we can expect the great majority of folks to have updated?
cc @whimsical-sam