### PR TITLE
fix [crow] autoconnection subpatch

### DIFF
--- a/crow_max/crow.maxpat
+++ b/crow_max/crow.maxpat
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 1,
-			"revision" : 0,
+			"minor" : 0,
+			"revision" : 3,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -70,7 +70,7 @@
 					"presentation" : 1,
 					"presentation_rect" : [ 127.0, 165.5, 46.0, 22.0 ],
 					"text" : "refresh",
-					"textcolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ]
+					"textcolor" : [ 0.996078431606293, 0.996078431606293, 0.996078431606293, 1.0 ]
 				}
 
 			}
@@ -184,7 +184,7 @@
 					"bgfillcolor_proportion" : 0.5,
 					"bgfillcolor_type" : "color",
 					"id" : "obj-2",
-					"items" : [ "Bluetooth-Incoming-Port", ",", "usbmodem3072357931371" ],
+					"items" : "COM10",
 					"maxclass" : "umenu",
 					"numinlets" : 1,
 					"numoutlets" : 3,
@@ -208,8 +208,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 0,
+							"minor" : 0,
+							"revision" : 3,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -253,8 +253,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 0,
+											"minor" : 0,
+											"revision" : 3,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -363,8 +363,8 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 225.5, 132.0, 103.0, 22.0 ],
-													"text" : "regexp COM[0-9]"
+													"patching_rect" : [ 225.5, 132.0, 105.0, 22.0 ],
+													"text" : "regexp COM[0-9]*"
 												}
 
 											}
@@ -375,7 +375,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 97.5, 287.0, 96.0, 22.0 ],
+													"patching_rect" : [ 89.0, 287.0, 96.0, 22.0 ],
 													"text" : "prepend symbol"
 												}
 
@@ -387,7 +387,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 97.5, 171.0, 40.0, 22.0 ],
+													"patching_rect" : [ 89.0, 171.0, 40.0, 22.0 ],
 													"text" : "zl.reg"
 												}
 
@@ -399,8 +399,8 @@
 													"numinlets" : 1,
 													"numoutlets" : 5,
 													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 51.0, 132.0, 154.0, 22.0 ],
-													"text" : "regexp usbmodem14[0-9]1"
+													"patching_rect" : [ 51.0, 132.0, 137.0, 22.0 ],
+													"text" : "regexp usbmodem[0-9]*"
 												}
 
 											}
@@ -426,7 +426,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 96.5, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 89.0, 40.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -438,7 +438,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 97.5, 351.0, 30.0, 30.0 ]
+													"patching_rect" : [ 89.0, 351.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -535,7 +535,8 @@
 										"tags" : ""
 									}
 ,
-									"text" : "p autoselect"
+									"text" : "p autoselect",
+									"varname" : "autoselect"
 								}
 
 							}
@@ -984,7 +985,8 @@
 						"tags" : ""
 					}
 ,
-					"text" : "p serial"
+					"text" : "p serial",
+					"varname" : "serial"
 				}
 
 			}
@@ -1174,7 +1176,7 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "crowmax.lua",
-				"bootpath" : "~/Documents/GitHub/crow-max/crow_max",
+				"bootpath" : "~/Dropbox/crow/m4lfork/crow-max-and-m4l/crow_max",
 				"patcherrelativepath" : ".",
 				"type" : "Jlua",
 				"implicit" : 1

--- a/crow_max/crow.maxpat
+++ b/crow_max/crow.maxpat
@@ -94,7 +94,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 36.5, 295.0, 32.0, 22.0 ],
+					"patching_rect" : [ 53.5, 288.0, 32.0, 22.0 ],
 					"text" : "print"
 				}
 
@@ -184,7 +184,7 @@
 					"bgfillcolor_proportion" : 0.5,
 					"bgfillcolor_type" : "color",
 					"id" : "obj-2",
-					"items" : "COM10",
+					"items" : "<empty>",
 					"maxclass" : "umenu",
 					"numinlets" : 1,
 					"numoutlets" : 3,
@@ -1075,7 +1075,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-9", 2 ],
-					"midpoints" : [ 46.0, 318.0, 33.0, 318.0, 33.0, 249.0, 261.0, 249.0, 261.0, 213.0, 251.5, 213.0 ],
+					"midpoints" : [ 63.0, 318.0, 33.0, 318.0, 33.0, 249.0, 261.0, 249.0, 261.0, 213.0, 251.5, 213.0 ],
 					"source" : [ "obj-11", 0 ]
 				}
 
@@ -1090,7 +1090,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-11", 0 ],
-					"midpoints" : [ 136.5, 282.0, 46.0, 282.0 ],
+					"midpoints" : [ 136.5, 282.0, 63.0, 282.0 ],
 					"source" : [ "obj-19", 0 ]
 				}
 


### PR DESCRIPTION
- fixes `[crow] > [p serial] > [p autoconnect] > [regexp]` objects, which were not correctly catching all usbmodem/com port possibilities for crow.
- makes the `[umenu]` empty by default (instead of possibly showing a crow which is not actually connected)